### PR TITLE
Add integration tests for loyalty service

### DIFF
--- a/src/backend/loyalty/tests/helpers/credentials-helper.ts
+++ b/src/backend/loyalty/tests/helpers/credentials-helper.ts
@@ -1,0 +1,27 @@
+import Sts, { AssumeRoleRequest } from 'aws-sdk/clients/sts';
+
+const sts = new Sts();
+
+interface Credentials {
+  accessKeyId: string,
+  secretAccessKey: string,
+  sessionToken: string
+}
+
+export async function getCredentials(roleArn: string, externalId: string | undefined): Promise<Credentials> {
+  const params:AssumeRoleRequest = {
+    RoleArn: roleArn,
+    DurationSeconds: 900,
+    RoleSessionName: 'AirlineTest'
+  };
+  if (externalId !== undefined) {
+    params.ExternalId = externalId;
+  }
+  const result = await sts.assumeRole(params).promise();
+
+  return {
+    accessKeyId: result.Credentials!.AccessKeyId,
+    secretAccessKey: result.Credentials!.SecretAccessKey,
+    sessionToken: result.Credentials!.SessionToken
+  };
+}

--- a/src/backend/loyalty/tests/helpers/dynamodb-helper.ts
+++ b/src/backend/loyalty/tests/helpers/dynamodb-helper.ts
@@ -1,0 +1,69 @@
+import DynamoDB, { DocumentClient } from 'aws-sdk/clients/dynamodb';
+import { PutInput } from '../../src/ingest/lib/document_client';
+
+interface Credentials {
+  accessKeyId: string,
+  secretAccessKey: string,
+  sessionToken: string
+}
+
+export async function getDbInstance(credentials:Credentials|undefined): Promise<DynamoDB> {
+  return new DynamoDB(credentials);
+}
+
+export async function createTable(tableName: string, dynamoDb: DynamoDB): Promise<Object> {
+  const params = {
+    AttributeDefinitions: [{
+      AttributeName: 'customerId',
+      AttributeType: 'S'
+    },
+    {
+      AttributeName: 'flag',
+      AttributeType: 'S'
+    },
+    {
+      AttributeName: 'id',
+      AttributeType: 'S'
+    }],
+    KeySchema: [{
+      AttributeName: "id",
+      KeyType: "HASH"
+    }],
+    GlobalSecondaryIndexes: [{
+      IndexName: 'customer-flag',
+      KeySchema: [{
+        AttributeName: 'customerId',
+        KeyType: 'HASH'
+      },
+      {
+        AttributeName: 'flag',
+        KeyType: 'RANGE'
+      }],
+      Projection: {
+        ProjectionType: 'ALL'
+      }
+    }],
+    BillingMode: 'PAY_PER_REQUEST',
+    TableName: tableName
+  };
+  await dynamoDb.createTable(params).promise();
+
+  return dynamoDb.waitFor('tableExists', {
+    TableName: tableName
+  }).promise();
+}
+
+export async function deleteTable(tableName: string, dynamoDb: DynamoDB): Promise<Object> {
+  // Destroy a table at the end of our tests
+  return await dynamoDb.deleteTable({
+    TableName: tableName
+  }).promise();
+}
+
+export async function insertData(tableName: string, data: Object, docClient: DocumentClient): Promise<Object> {
+  const params: PutInput = {
+    TableName: tableName,
+    Item: data
+  };
+  return await docClient.put(params).promise();
+}

--- a/src/backend/loyalty/tests/helpers/timeout-helper.ts
+++ b/src/backend/loyalty/tests/helpers/timeout-helper.ts
@@ -1,0 +1,7 @@
+export async function wait(timeout: number): Promise<void> {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve();
+    }, timeout);
+  });
+}

--- a/src/backend/loyalty/tests/integration.test.ts
+++ b/src/backend/loyalty/tests/integration.test.ts
@@ -1,0 +1,176 @@
+/*
+  Environment variables:
+  - `LOYALTY_INTEG_ROLE` (optional): Arn for an existing role that will be assumed in integration tests
+  - `DYNAMODB_TABLE` (optional): Provide the name of an existing DynamoDB table to speed up the tests
+  - `QUERY_TIMEOUT` (optional): A timeout in milliseconds between writing data to the table and running a query, because of eventual consitency of queries on global secondary indexes
+*/
+import DynamoDB, { DocumentClient } from 'aws-sdk/clients/dynamodb';
+import { getCredentials } from './helpers/credentials-helper';
+import { getDbInstance, createTable, deleteTable, insertData } from './helpers/dynamodb-helper';
+import { wait } from './helpers/timeout-helper';
+import uuidv4 from 'uuid/v4';
+
+import { addPoints } from '../src/ingest';
+import { points } from '../src/get';
+
+let dynamoDb:DynamoDB, documentClient:DocumentClient;
+
+// Table name for test DynamoDB
+const tableName = process.env.DYNAMODB_TABLE ? process.env.DYNAMODB_TABLE : `airline-test-table-${uuidv4()}`;
+// Query timeout
+const queryTimeout: number = process.env.QUERY_TIMEOUT ? parseInt(process.env.QUERY_TIMEOUT, 10) : 200;
+
+describe('integration', () => {
+  beforeAll(async () => {
+    let credentials;
+    // If LOYALTY_INTEG_ROLE is provided, assume it
+    if (process.env.LOYALTY_INTEG_ROLE !== undefined) {
+      credentials = await getCredentials(process.env.LOYALTY_INTEG_ROLE, process.env.LOYALTY_INTEG_EXTERNAL_ID);
+    }
+
+    // Initialize DynamoDB instance with assumed role or default credentials
+    dynamoDb = await getDbInstance(credentials);
+
+    // Initialize document client with assumed role or default credentials
+    documentClient = new DocumentClient(credentials);
+
+    // If the existing DynamoDB table is not provided
+    if (!process.env.DYNAMODB_TABLE) {
+      // Create a new DynamoDB table
+      return await createTable(tableName, dynamoDb);
+    }
+
+    // Otherwise return a promise
+    return Promise.resolve();
+  }, 90000); // Increase the timeout for `beforeAll` to 90s, because deleting table takes time
+
+  afterAll(async () => {
+    // If the existing DynamoDB table is not provided
+    if (!process.env.DYNAMODB_TABLE) {
+      // Delete the DynamoDB table used for testing
+      return await deleteTable(tableName, dynamoDb);
+    }
+  }, 90000); // Increase the timeout for `afterAll` to 90s, because deleting table takes time
+
+  describe('ingest', () => {
+    test('should write to loyalty table', async () => {
+      const customerId = uuidv4();
+      await addPoints(customerId, 1235, documentClient, tableName);
+
+      // A short delay, because of eventual consitency of queries on global secondary indexes
+      await wait(queryTimeout);
+      
+      const params = {
+        TableName: tableName,
+        IndexName: "customer-flag",
+        KeyConditionExpression: 'customerId = :hkey and flag = :rkey',
+        ExpressionAttributeValues: {
+          ':hkey': customerId,
+          ':rkey': 'active'
+        }
+      };
+      
+      const result = await documentClient.query(params).promise();
+      
+      expect(Array.isArray(result.Items)).toBeTruthy();
+      expect(result.Items!.length).toBe(1);
+      expect(result.Items![0].customerId).toBe(customerId);
+    });
+    
+    test('should write multiple entries for the same customer id', async () => {
+      const customerId = uuidv4();
+      await addPoints(customerId, 100, documentClient, tableName);
+      await addPoints(customerId, 200, documentClient, tableName);
+      
+      await wait(queryTimeout);
+      
+      const params = {
+        TableName: tableName,
+        IndexName: "customer-flag",
+        KeyConditionExpression: 'customerId = :hkey and flag = :rkey',
+        ExpressionAttributeValues: {
+          ':hkey': customerId,
+          ':rkey': 'active'
+        }
+      };
+      
+      const result = await documentClient.query(params).promise();
+      
+      expect(Array.isArray(result.Items)).toBeTruthy();
+      expect(result.Items!.length).toBe(2);
+      expect(result.Items![0].points + result.Items![1].points).toBe(300);
+    });
+  });
+  
+  describe('get', () => {
+    test('should throw the "no data" error if no entries were found', async () => {
+      const customerId = uuidv4();
+      try {
+        await points(customerId, documentClient, tableName);
+      } catch (err) {
+        expect(err).toContain('No data');
+      }
+    });
+
+    test('should return points for a single found entry', async () => {
+      const customerId = uuidv4();
+      const data = {
+        id: uuidv4(),
+        customerId: customerId,
+        points: 100,
+        flag: 'active',
+        date: new Date().toISOString()
+      };
+      await insertData(tableName, data, documentClient);
+
+      await wait(queryTimeout);
+
+      const numberOfPoints = await points(customerId, documentClient, tableName);
+      expect(numberOfPoints).toBe(100);
+    });
+
+    test('should return a sum of points for all entries', async () => {
+      const customerId = uuidv4();
+      await Promise.all([100, 200, 300].map(points => {
+        const data = {
+          id: uuidv4(),
+          customerId: customerId,
+          points: points,
+          flag: 'active',
+          date: new Date().toISOString()
+        };
+        return insertData(tableName, data, documentClient);
+      }));
+
+      await wait(queryTimeout);
+
+      const numberOfPoints = await points(customerId, documentClient, tableName);
+      expect(numberOfPoints).toBe(600);
+    });
+  });
+
+  describe('ingest and get integration', () => {
+    test('should insert an entry using ingest and read them using get', async () => {
+      const customerId = uuidv4();
+      await addPoints(customerId, 1235, documentClient, tableName);
+
+      await wait(queryTimeout);
+
+      const numberOfPoints = await points(customerId, documentClient, tableName);
+      expect(numberOfPoints).toBe(1235);
+    });
+
+    test('should insert an entry using ingest and read them using get', async () => {
+      const customerId = uuidv4();
+      await Promise.all([100, 200, 300].map(points => {
+        return addPoints(customerId, points, documentClient, tableName);
+      }));
+
+      await wait(queryTimeout);
+
+      const numberOfPoints = await points(customerId, documentClient, tableName);
+      expect(numberOfPoints).toBe(600);
+    });
+  });
+
+});


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Adding integration tests for `get` and `ingest` functions of the Loyalty service.

# Documentation

Integration tests for loyalty service are in the `src/backend/loyalty/integration.test.ts` file. That file contain tests for `ingest` and `get` functions, and also tests for integration of these two functions.

By default, tests will create a new DynamoDB table, use that table to run the tests, and delete the table in the end. However, you can change the behavior of `beforeAll` and `afterAll` scripts by passing some or all of the following environment variables:

- `LOYALTY_INTEG_ROLE` (optional): Arn for an existing role that will be assumed in integration tests.
- `DYNAMODB_TABLE` (optional): Provide the name of an existing DynamoDB table to speed up the tests.
- `QUERY_TIMEOUT` (optional): A timeout in milliseconds between writing data to the table and running a query, because of eventual consistency  of queries on global secondary indexes. Default timeout is 200ms.

## Running tests

To run all unit and integration tests use the following command*:

```bash
AWS_REGION=eu-west-1 npm t
```

To filter tests, use Jest's `-t` option. If you are running tests using the NPM test command, you'll need to pass `--` before `-t`, as `--` tells NPM to pass the following options to Jest command. For example, following command will run only integration tests:

```bash
AWS_REGION=eu-west-1 npm t -- -t "integration"
```

If you want to use a custom role for the tests, use the following command:
```
LOYALTY_INTEG_ROLE="REPLACE_WITH_ROLE_ARN" AWS_REGION=eu-west-1 npm t
```

To pass an existing DynamoDB table, use the following command:
```
DYNAMODB_TABLE ="REPLACE_WITH_DYNAMODB_TABLE_NAME" AWS_REGION=eu-west-1 npm t
```

To combine the options, simply set multiple environment variables, for example, if you want to set the timeout and use the existing DynamoDB table, run the following command:

```
QUERY_TIMEOUT=300 DYNAMODB_TABLE ="REPLACE_WITH_DYNAMODB_TABLE_NAME" AWS_REGION=eu-west-1 npm t
```

_* Note: setting environment variables can work differently on different operating systems._

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
